### PR TITLE
Ignore cr

### DIFF
--- a/Tasks/ShellScript/shellscript.ts
+++ b/Tasks/ShellScript/shellscript.ts
@@ -20,7 +20,8 @@ async function run() {
         }
         tl.mkdirP(cwd);
         tl.cd(cwd);
-
+        
+        bash.arg("-o igncr");
         bash.arg(scriptPath);
 
         // additional args should always call argString.  argString() parses quoted arg strings


### PR DESCRIPTION
Ignore cr (carriage return) so we can processs sh that came from a  windows pull/build and had crlf added.

This could be an advanced option too that's off by default but want to get the authors thoughts. 
